### PR TITLE
Add port scanning and Docker socket identification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Examples and experiments using different programming frameworks and libraries. T
 ### Terraform LAMP Stack Deployment
 This section provides an example of deploying a LAMP stack (Linux, Apache, MySQL, PHP) on Azure using Terraform. The Terraform files for this deployment can be found in the `modules/lamp_stack` directory. This example demonstrates how to define resources, configure security groups, and set up a LAMP stack on an Azure virtual machine.
 
+### Port Scanning and Docker Socket Identification
+This section provides an example of a Python script to perform port scanning and identify Docker sockets on a local network. The script scans the local network for open ports and identifies Docker sockets using the `socket` and `docker` libraries.
+
 ## Getting Started
 
 To get started with the experiments in this repository, follow these steps:
@@ -48,6 +51,25 @@ To get started with the experiments in this repository, follow these steps:
 
 3. **Explore the Experiments**:
     - Navigate to the respective directories and run the scripts or notebooks.
+
+## Running the Port Scanning and Docker Socket Identification Script
+
+To run the `port_scan.py` script, follow these steps:
+
+1. **Install Dependencies**:
+    Ensure you have the required dependencies installed:
+    ```sh
+    pip install docker
+    ```
+
+2. **Run the Script**:
+    Execute the `port_scan.py` script:
+    ```sh
+    python port_scan.py
+    ```
+
+3. **View the Results**:
+    The script will output the open ports and identified Docker sockets on the local network.
 
 ## Contributing
 

--- a/port_scan.py
+++ b/port_scan.py
@@ -1,0 +1,31 @@
+import socket
+import docker
+
+def scan_ports(ip):
+    open_ports = []
+    for port in range(1, 65535):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(1)
+        result = sock.connect_ex((ip, port))
+        if result == 0:
+            open_ports.append(port)
+        sock.close()
+    return open_ports
+
+def identify_docker_sockets(open_ports):
+    docker_sockets = []
+    client = docker.from_env()
+    for port in open_ports:
+        try:
+            client.ping()
+            docker_sockets.append(port)
+        except docker.errors.APIError:
+            continue
+    return docker_sockets
+
+if __name__ == "__main__":
+    ip = "127.0.0.1"  # Change this to the target IP address
+    open_ports = scan_ports(ip)
+    print(f"Open ports: {open_ports}")
+    docker_sockets = identify_docker_sockets(open_ports)
+    print(f"Docker sockets: {docker_sockets}")


### PR DESCRIPTION
Add a Python script for port scanning and Docker socket identification.

* **port_scan.py**: 
  - Import `socket` and `docker` libraries.
  - Define `scan_ports` function to scan the local network for open ports.
  - Define `identify_docker_sockets` function to identify Docker sockets.
  - Implement main script logic to call `scan_ports` and `identify_docker_sockets`.

* **README.md**:
  - Add a section "Port Scanning and Docker Socket Identification".
  - Provide instructions on how to run the `port_scan.py` script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nolecram/HelpMeCopilot/pull/28?shareId=56a26a9e-d6fc-4ddf-b29c-40014f249d00).